### PR TITLE
Add connection property to disable file transfers

### DIFF
--- a/src/main/java/net/snowflake/client/core/SFSession.java
+++ b/src/main/java/net/snowflake/client/core/SFSession.java
@@ -99,6 +99,8 @@ public class SFSession extends SFBaseSession {
   private Telemetry telemetryClient;
   private SnowflakeConnectString sfConnStr;
 
+  private boolean disableFileTransfer = false;
+
   // This constructor is used only by tests with no real connection.
   // For real connections, the other constructor is always used.
   @VisibleForTesting
@@ -349,6 +351,11 @@ public class SFSession extends SFBaseSession {
             privateKeyPassword = (String) propertyValue;
           }
           break;
+
+        case DISABLE_FILE_TRANSFER:
+          if (propertyValue != null) {
+            disableFileTransfer = (Boolean) propertyValue;
+          }
 
         default:
           break;
@@ -889,6 +896,10 @@ public class SFSession extends SFBaseSession {
 
   public void setEnableCombineDescribe(boolean enable) {
     this.enableCombineDescribe = enable;
+  }
+
+  public boolean isFileTransferDisabled() {
+    return this.disableFileTransfer;
   }
 
   @Override

--- a/src/main/java/net/snowflake/client/core/SFSessionProperty.java
+++ b/src/main/java/net/snowflake/client/core/SFSessionProperty.java
@@ -55,6 +55,7 @@ public enum SFSessionProperty {
   INJECT_WAIT_IN_PUT("inject_wait_in_put", false, Integer.class),
   PRIVATE_KEY_FILE("private_key_file", false, String.class),
   PRIVATE_KEY_FILE_PWD("private_key_file_pwd", false, String.class),
+  DISABLE_FILE_TRANSFER("disableFileTransfer", false, Boolean.class),
   CLIENT_INFO("snowflakeClientInfo", false, String.class),
   ALLOW_UNDERSCORES_IN_HOST("allowUnderscoresInHost", false, Boolean.class);
 

--- a/src/main/java/net/snowflake/client/core/SFStatement.java
+++ b/src/main/java/net/snowflake/client/core/SFStatement.java
@@ -119,6 +119,10 @@ public class SFStatement extends SFBaseStatement {
 
     // snowflake specific client side commands
     if (isFileTransfer(trimmedSql)) {
+      if (this.session.isFileTransferDisabled()) {
+        throw new SnowflakeSQLException(
+            ErrorCode.INVALID_SQL, "file transfers are disabled for this connection");
+      }
       // PUT/GET command
       logger.debug("Executing file transfer locally: {}", sql);
 


### PR DESCRIPTION
This change adds a connection property called `disableFileTransfers`. If set to `true`, it throws a SQLException if the user attempts to use a `PUT` or `GET` command without performing the transfer.